### PR TITLE
Update instructions

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>PM5 Monitor</title>
     <link rel="manifest" href="/manifest.json">
-    <!--<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">-->
     <meta name="theme-color" content="#0097A7">    
     <script async src="js/app.js" type="text/javascript"></script>
     <style type="text/css">
@@ -61,19 +60,18 @@
         }
         
         .header {
-            color: white;            
+            color: white;
         }
 
         .appbar {
             height: 56px;
             display: flex;
-            padding: 8px;
+            padding: 8px 16px;
             background-color: #0097A7;
         }
         
         .logo {
             width: 70%;
-            margin-left: 16px;
         }
         
         .toolbar {
@@ -132,12 +130,11 @@
         }        
 
         .page-header {
-            /*background-color: lightgray;*/
-            padding: 4px 8px;
+            padding: 4px 16px;
         }
 
         .page-content {
-            padding: 8px;
+            padding: 8px 16px;
         }
 
         .onoffswitch {
@@ -227,10 +224,6 @@
                 <div class="instructions">
                     <h3>Instructions</h3>
                     <div>
-                        <p>
-                            In Chrome 56 or later, go to <em>chrome://flags/#enable-experimental-web-platform-features</em>
-                            otherwise go to <em>chrome://flags/#enable-web-bluetooth</em>
-                        </p>                    
                         <p>
                             On the PM5 monitor, go to More Options > Enable Wireless to enable Bluetooth connections.
                         </p>

--- a/src/js/pm5.js
+++ b/src/js/pm5.js
@@ -94,6 +94,7 @@ export default class PM5 {
       .then(device => {
         this.device = device;
         this.device.addEventListener('gattserverdisconnected', () => {
+          this.idObjectMap.clear();
           this.eventTarget.dispatchEvent({type: 'disconnect'});
         });
         return device.gatt.connect();
@@ -105,7 +106,6 @@ export default class PM5 {
   }
 
   disconnect() {
-    this.idObjectMap.clear();
     if (!this.device || !this.device.gatt) {
       return Promise.resolve();
     }


### PR DESCRIPTION
On latest Chrome versions, web-bluetooth is enabled by default.
Removed old instructions.