### PR TITLE
Fix overflowing content

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,11 @@
             box-sizing: border-box;
         }
 
+        body {
+            width: 100vw;
+            overflow: hidden;
+        }
+        
         body,
         h1 {
             margin: 0;


### PR DESCRIPTION
The hidden tab to the right was making the content overflow.
Added width=100vw to body and overflow-x=hidden to fix.