### PR TITLE
Release WakeLock on disconnect event

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -126,13 +126,13 @@ class App {
         return this.pm5.addEventListener('disconnect', () => {
           this.btOnOffSwitch.checked = false;
           this.statusText.textContent = 'Disconnected';
+          screen.keepAwake = false;
         });
       });
   }
 
   disconnect() {
     this.pm5.disconnect();
-    screen.keepAwake = false;
   }
 
   _addWorkout(workoutTable, rowtemplate, workout) {


### PR DESCRIPTION
WakeLock was being released when the method was invoked. Releasing
on the `disconnect` event is more appropriate and cover the
disconnection being caused by the PM5.