### PR TITLE
add external-helpers plug-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "babel-cli": "^6.18.0",
+    "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-es2015": "^6.18.0",
     "del": "^2.2.2",
     "eslint": "^3.10.1",


### PR DESCRIPTION
Added missing "babel-plugin-external-helpers" lib in package.json.
